### PR TITLE
Fix settings['headers'] access in client

### DIFF
--- a/lib/grafana/client.rb
+++ b/lib/grafana/client.rb
@@ -70,7 +70,7 @@ module Grafana
       @logger = Logger.new(STDOUT)
       @headers = nil
 
-      if settings['headers'].key?('Authorization')
+      if settings.has_key?('headers') && settings['headers'].key?('Authorization')
         # API key Auth
         @headers = {
           :content_type => 'application/json; charset=UTF-8',


### PR DESCRIPTION
Client silently assumes, that `headers` key is always present in `settings` hash, which does not necessarily has to be the case.