### PR TITLE
Improve params handling in Dashboard.search_dashboards

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -73,5 +73,5 @@ g.get_dashboard_tags()
 
 ##### Search for dashboard:
 ```ruby
-g.search_dashboards({"query" => "My Dashboard", "tags" => 'test'})
+g.search_dashboards({"query" => "My Dashboard", "tag" => 'test'})
 ```

--- a/lib/grafana/dashboard.rb
+++ b/lib/grafana/dashboard.rb
@@ -57,9 +57,14 @@ module Grafana
     end
 
     def search_dashboards(params={})
-      params['query'] = (params['query'].length >= 1 ? CGI::escape(params['query']) : '' )
-      params['starred'] = (params['starred'] ? 'true' : 'false')
-      endpoint = "/api/search/?query=#{params['query']}&starred=#{params['starred']}&tag=#{params['tags']}"
+      query = CGI::escape(params['query'] || '')
+      tag = params['tag']
+      starred = params['starred'] && params['starred'].is_a?(TrueClass)
+
+      endpoint = "/api/search/?query=#{query}"
+      endpoint += "&tag=#{tag}" if tag
+      endpoint += "&starred=#{starred}" if starred
+
       @logger.info("Attempting to search for dashboards (GET #{endpoint})") if @debug
       return get_request(endpoint)
     end


### PR DESCRIPTION
Previously, with no `params['tags']` provided, endpoint url was getting an empty `...&tag=` param resulting in no hits, even if the `params['query']` was set correctly.